### PR TITLE
Add `§v` color code

### DIFF
--- a/entries/colors.yaml
+++ b/entries/colors.yaml
@@ -20,6 +20,9 @@ body: |
     `§f` White
     `§g` Minecoin Gold
     
+    `§h` Quartz
+    `§i` Iron
+    `§j` Netherite
     `§m` Redstone
     `§n` Copper
     `§p` Gold
@@ -27,9 +30,7 @@ body: |
     `§s` Diamond
     `§t` Lapis
     `§u` Amethyst
-    `§h` Quartz
-    `§i` Iron
-    `§j` Netherite
+    `§v` Resin
     
     `§k` Obfuscated
     `§l` Bold


### PR DESCRIPTION
`§v`, colored `#EB7114`, was added in 1.21.50 for use for the resin armor trim material. I also made the material color codes be in order, which the last few weren't.